### PR TITLE
Change preferred_run_mode to user

### DIFF
--- a/lib/puppet/face/code_manager.rb
+++ b/lib/puppet/face/code_manager.rb
@@ -128,7 +128,7 @@ class DeployCall
       @cert_store = get_store(options[:ca_cert])
     end
 
-    Puppet.settings.preferred_run_mode = "agent"
+    Puppet.settings.preferred_run_mode = "user"
     code_manager_host = options[:cmserver] || Puppet[:server]
     code_manager_port = options[:cmport] || DEFAULT_CODE_MANAGER_PORT
 


### PR DESCRIPTION
I've installed the code_manager face on a workstation that isn't meant to have a running puppet agent and is just used as a client which interacts with PE infrastructure. To this end, I've purposefully set `server = nonsense` in the `agent` section of my `puppet.conf` in order to keep agent actions, like a reflexive, `puppet agent -t`, from submitting cert requests to the PE master or performing other actions which have to be cleaned up. However, this safeguard also disables the `code_manager` face.

This patch changes the preferred run mode of the `code_manger` face to `user` which is more suitable for its role as a client tool.
